### PR TITLE
Remove implementation of Certificate resource deletion

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-12-28T21:02:41Z"
+  build_date: "2024-01-09T17:47:35Z"
   build_hash: 66f2265b640acee87a394afaf979d24d9fbce38a
   go_version: go1.21.0
   version: v0.28.0
-api_directory_checksum: bc9722dbc454fa22e694bdd7592758af787ba913
+api_directory_checksum: 4f30b45a458872137ce82316fe8486cea6c7944b
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.6
 generator_config_info:
-  file_checksum: 402249c8282236c6ec6a3a1d04267de5a1b95b72
+  file_checksum: a338d4e7fd329f87ecb7e3e89af570530d69d071
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/certificate.go
+++ b/apis/v1alpha1/certificate.go
@@ -40,19 +40,6 @@ type CertificateSpec struct {
 	// arn:aws:acm-pca:region:account:certificate-authority/12345678-1234-1234-1234-123456789012
 	CertificateAuthorityARN *string                                  `json:"certificateAuthorityARN,omitempty"`
 	CertificateAuthorityRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"certificateAuthorityRef,omitempty"`
-	// Serial number of the certificate to be revoked. This must be in hexadecimal
-	// format. You can retrieve the serial number by calling GetCertificate (https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html)
-	// with the Amazon Resource Name (ARN) of the certificate you want and the ARN
-	// of your private CA. The GetCertificate action retrieves the certificate in
-	// the PEM format. You can use the following OpenSSL command to list the certificate
-	// in text format and copy the hexadecimal serial number.
-	//
-	// openssl x509 -in file_path -text -noout
-	//
-	// You can also copy the serial number from the console or use the DescribeCertificate
-	// (https://docs.aws.amazon.com/acm/latest/APIReference/API_DescribeCertificate.html)
-	// action in the Certificate Manager API Reference.
-	CertificateSerial *string `json:"certificateSerial,omitempty"`
 	// The certificate signing request (CSR) for the certificate you want to issue.
 	// As an example, you can use the following OpenSSL command to create the CSR
 	// and a 2048 bit RSA private key.
@@ -71,8 +58,6 @@ type CertificateSpec struct {
 	// or the request will be rejected.
 	CSR    []byte                                   `json:"csr,omitempty"`
 	CSRRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"csrRef,omitempty"`
-	// Specifies why you revoked the certificate.
-	RevocationReason *string `json:"revocationReason,omitempty"`
 	// The name of the algorithm that will be used to sign the certificate to be
 	// issued.
 	//

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -12,10 +12,6 @@ operations:
     operation_type:
     - Create
     resource_name: Certificate
-  RevokeCertificate:
-    operation_type:
-    - Delete
-    resource_name: Certificate
   ImportCertificateAuthorityCertificate:
     operation_type:
     - Create
@@ -68,14 +64,6 @@ resources:
         references:
           resource: CertificateAuthority
           path: Status.CSR
-      CertificateSerial:
-        from:
-          operation: RevokeCertificate
-          path: CertificateSerial
-      RevocationReason:
-        from:
-          operation: RevokeCertificate
-          path: RevocationReason
     tags:
       ignore: true
   CertificateAuthorityActivation:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -745,11 +745,6 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.CertificateSerial != nil {
-		in, out := &in.CertificateSerial, &out.CertificateSerial
-		*out = new(string)
-		**out = **in
-	}
 	if in.CSR != nil {
 		in, out := &in.CSR, &out.CSR
 		*out = make([]byte, len(*in))
@@ -759,11 +754,6 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		in, out := &in.CSRRef, &out.CSRRef
 		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.RevocationReason != nil {
-		in, out := &in.RevocationReason, &out.RevocationReason
-		*out = new(string)
-		**out = **in
 	}
 	if in.SigningAlgorithm != nil {
 		in, out := &in.SigningAlgorithm, &out.SigningAlgorithm

--- a/config/crd/bases/acmpca.services.k8s.aws_certificates.yaml
+++ b/config/crd/bases/acmpca.services.k8s.aws_certificates.yaml
@@ -290,19 +290,6 @@ spec:
                         type: string
                     type: object
                 type: object
-              certificateSerial:
-                description: "Serial number of the certificate to be revoked. This
-                  must be in hexadecimal format. You can retrieve the serial number
-                  by calling GetCertificate (https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html)
-                  with the Amazon Resource Name (ARN) of the certificate you want
-                  and the ARN of your private CA. The GetCertificate action retrieves
-                  the certificate in the PEM format. You can use the following OpenSSL
-                  command to list the certificate in text format and copy the hexadecimal
-                  serial number. \n openssl x509 -in file_path -text -noout \n You
-                  can also copy the serial number from the console or use the DescribeCertificate
-                  (https://docs.aws.amazon.com/acm/latest/APIReference/API_DescribeCertificate.html)
-                  action in the Certificate Manager API Reference."
-                type: string
               csr:
                 description: "The certificate signing request (CSR) for the certificate
                   you want to issue. As an example, you can use the following OpenSSL
@@ -330,9 +317,6 @@ spec:
                         type: string
                     type: object
                 type: object
-              revocationReason:
-                description: Specifies why you revoked the certificate.
-                type: string
               signingAlgorithm:
                 description: "The name of the algorithm that will be used to sign
                   the certificate to be issued. \n This parameter should not be confused

--- a/generator.yaml
+++ b/generator.yaml
@@ -12,10 +12,6 @@ operations:
     operation_type:
     - Create
     resource_name: Certificate
-  RevokeCertificate:
-    operation_type:
-    - Delete
-    resource_name: Certificate
   ImportCertificateAuthorityCertificate:
     operation_type:
     - Create
@@ -68,14 +64,6 @@ resources:
         references:
           resource: CertificateAuthority
           path: Status.CSR
-      CertificateSerial:
-        from:
-          operation: RevokeCertificate
-          path: CertificateSerial
-      RevocationReason:
-        from:
-          operation: RevokeCertificate
-          path: RevocationReason
     tags:
       ignore: true
   CertificateAuthorityActivation:

--- a/helm/crds/acmpca.services.k8s.aws_certificates.yaml
+++ b/helm/crds/acmpca.services.k8s.aws_certificates.yaml
@@ -290,19 +290,6 @@ spec:
                         type: string
                     type: object
                 type: object
-              certificateSerial:
-                description: "Serial number of the certificate to be revoked. This
-                  must be in hexadecimal format. You can retrieve the serial number
-                  by calling GetCertificate (https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html)
-                  with the Amazon Resource Name (ARN) of the certificate you want
-                  and the ARN of your private CA. The GetCertificate action retrieves
-                  the certificate in the PEM format. You can use the following OpenSSL
-                  command to list the certificate in text format and copy the hexadecimal
-                  serial number. \n openssl x509 -in file_path -text -noout \n You
-                  can also copy the serial number from the console or use the DescribeCertificate
-                  (https://docs.aws.amazon.com/acm/latest/APIReference/API_DescribeCertificate.html)
-                  action in the Certificate Manager API Reference."
-                type: string
               csr:
                 description: "The certificate signing request (CSR) for the certificate
                   you want to issue. As an example, you can use the following OpenSSL
@@ -330,9 +317,6 @@ spec:
                         type: string
                     type: object
                 type: object
-              revocationReason:
-                description: Specifies why you revoked the certificate.
-                type: string
               signingAlgorithm:
                 description: "The name of the algorithm that will be used to sign
                   the certificate to be issued. \n This parameter should not be confused

--- a/pkg/resource/certificate/delta.go
+++ b/pkg/resource/certificate/delta.go
@@ -265,25 +265,11 @@ func newResourceDelta(
 	if !reflect.DeepEqual(a.ko.Spec.CertificateAuthorityRef, b.ko.Spec.CertificateAuthorityRef) {
 		delta.Add("Spec.CertificateAuthorityRef", a.ko.Spec.CertificateAuthorityRef, b.ko.Spec.CertificateAuthorityRef)
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.CertificateSerial, b.ko.Spec.CertificateSerial) {
-		delta.Add("Spec.CertificateSerial", a.ko.Spec.CertificateSerial, b.ko.Spec.CertificateSerial)
-	} else if a.ko.Spec.CertificateSerial != nil && b.ko.Spec.CertificateSerial != nil {
-		if *a.ko.Spec.CertificateSerial != *b.ko.Spec.CertificateSerial {
-			delta.Add("Spec.CertificateSerial", a.ko.Spec.CertificateSerial, b.ko.Spec.CertificateSerial)
-		}
-	}
 	if !bytes.Equal(a.ko.Spec.CSR, b.ko.Spec.CSR) {
 		delta.Add("Spec.CSR", a.ko.Spec.CSR, b.ko.Spec.CSR)
 	}
 	if !reflect.DeepEqual(a.ko.Spec.CSRRef, b.ko.Spec.CSRRef) {
 		delta.Add("Spec.CSRRef", a.ko.Spec.CSRRef, b.ko.Spec.CSRRef)
-	}
-	if ackcompare.HasNilDifference(a.ko.Spec.RevocationReason, b.ko.Spec.RevocationReason) {
-		delta.Add("Spec.RevocationReason", a.ko.Spec.RevocationReason, b.ko.Spec.RevocationReason)
-	} else if a.ko.Spec.RevocationReason != nil && b.ko.Spec.RevocationReason != nil {
-		if *a.ko.Spec.RevocationReason != *b.ko.Spec.RevocationReason {
-			delta.Add("Spec.RevocationReason", a.ko.Spec.RevocationReason, b.ko.Spec.RevocationReason)
-		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.SigningAlgorithm, b.ko.Spec.SigningAlgorithm) {
 		delta.Add("Spec.SigningAlgorithm", a.ko.Spec.SigningAlgorithm, b.ko.Spec.SigningAlgorithm)

--- a/pkg/resource/certificate/sdk.go
+++ b/pkg/resource/certificate/sdk.go
@@ -493,35 +493,9 @@ func (rm *resourceManager) sdkDelete(
 	defer func() {
 		exit(err)
 	}()
-	input, err := rm.newDeleteRequestPayload(r)
-	if err != nil {
-		return nil, err
-	}
-	var resp *svcsdk.RevokeCertificateOutput
-	_ = resp
-	resp, err = rm.sdkapi.RevokeCertificateWithContext(ctx, input)
-	rm.metrics.RecordAPICall("DELETE", "RevokeCertificate", err)
-	return nil, err
-}
+	// TODO(jaypipes): Figure this out...
+	return nil, nil
 
-// newDeleteRequestPayload returns an SDK-specific struct for the HTTP request
-// payload of the Delete API call for the resource
-func (rm *resourceManager) newDeleteRequestPayload(
-	r *resource,
-) (*svcsdk.RevokeCertificateInput, error) {
-	res := &svcsdk.RevokeCertificateInput{}
-
-	if r.ko.Spec.CertificateAuthorityARN != nil {
-		res.SetCertificateAuthorityArn(*r.ko.Spec.CertificateAuthorityARN)
-	}
-	if r.ko.Spec.CertificateSerial != nil {
-		res.SetCertificateSerial(*r.ko.Spec.CertificateSerial)
-	}
-	if r.ko.Spec.RevocationReason != nil {
-		res.SetRevocationReason(*r.ko.Spec.RevocationReason)
-	}
-
-	return res, nil
 }
 
 // setStatusDefaults sets default properties into supplied custom resource


### PR DESCRIPTION
Removed implementation of Certificate resource deletion, since we do not want to support certificate revocation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
