### PR TITLE
Set CA immutable fields, update CA tags, and set CA fields to default values

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-01-10T16:51:57Z"
-  build_hash: 66f2265b640acee87a394afaf979d24d9fbce38a
+  build_date: "2024-01-16T19:59:02Z"
+  build_hash: ee97d5c7e02ce6ae940ad264018160dfe0961c7e
   go_version: go1.21.5
   version: v0.28.0
-api_directory_checksum: 1d6e5aa9bc3d0c9da85d6c4ad54b9a17bb1f21b8
+api_directory_checksum: c21cc54e1842f6dc598ef26beb5b59d559d0dba8
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.6
 generator_config_info:
-  file_checksum: 5bb70d4a2d6c71954f8a5bf93ee3c2fd30d0886f
+  file_checksum: c761cc34df325bd3343b2f0adfb38950143aedd8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-01-16T19:59:02Z"
+  build_date: "2024-01-17T21:16:22Z"
   build_hash: ee97d5c7e02ce6ae940ad264018160dfe0961c7e
   go_version: go1.21.5
   version: v0.28.0
@@ -7,7 +7,7 @@ api_directory_checksum: c21cc54e1842f6dc598ef26beb5b59d559d0dba8
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.6
 generator_config_info:
-  file_checksum: c761cc34df325bd3343b2f0adfb38950143aedd8
+  file_checksum: 2ee06fc21efd0b5566e33ba15dce90a44b76568c
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -26,8 +26,14 @@ prefix_config: {}
 resources:
   CertificateAuthority:
     hooks:
+      delta_pre_compare:
+        code: customSetDefaults(a, b)
       sdk_create_post_set_output:
         template_path: hooks/certificate_authority/sdk_create_post_set_output.go.tpl
+      sdk_update_pre_build_request:
+        template_path: hooks/certificate_authority/sdk_update_pre_build_request.go.tpl
+      sdk_read_one_post_set_output:
+        template_path: hooks/certificate_authority/sdk_read_one_post_set_output.go.tpl
     exceptions:
       terminal_codes:
       - InvalidAction

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -38,6 +38,14 @@ resources:
       - ValidationError
       - ValidationException
     fields: 
+      CertificateAuthorityConfiguration:
+        is_immutable: true
+      CertificateAuthorityType:
+        is_immutable: true
+      KeyStorageSecurityStandard:
+        is_immutable: true
+      UsageMode:
+        is_immutable: true
       CSR:
         is_read_only: true
         type: 'bytes'

--- a/generator.yaml
+++ b/generator.yaml
@@ -26,8 +26,14 @@ prefix_config: {}
 resources:
   CertificateAuthority:
     hooks:
+      delta_pre_compare:
+        code: customSetDefaults(a, b)
       sdk_create_post_set_output:
         template_path: hooks/certificate_authority/sdk_create_post_set_output.go.tpl
+      sdk_update_pre_build_request:
+        template_path: hooks/certificate_authority/sdk_update_pre_build_request.go.tpl
+      sdk_read_one_post_set_output:
+        template_path: hooks/certificate_authority/sdk_read_one_post_set_output.go.tpl
     exceptions:
       terminal_codes:
       - InvalidAction

--- a/generator.yaml
+++ b/generator.yaml
@@ -38,6 +38,14 @@ resources:
       - ValidationError
       - ValidationException
     fields: 
+      CertificateAuthorityConfiguration:
+        is_immutable: true
+      CertificateAuthorityType:
+        is_immutable: true
+      KeyStorageSecurityStandard:
+        is_immutable: true
+      UsageMode:
+        is_immutable: true
       CSR:
         is_read_only: true
         type: 'bytes'

--- a/pkg/resource/certificate/sdk.go
+++ b/pkg/resource/certificate/sdk.go
@@ -493,6 +493,7 @@ func (rm *resourceManager) sdkDelete(
 	defer func() {
 		exit(err)
 	}()
+
 	// TODO(jaypipes): Figure this out...
 	return nil, nil
 

--- a/pkg/resource/certificate_authority/custom_delta.go
+++ b/pkg/resource/certificate_authority/custom_delta.go
@@ -1,0 +1,56 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package certificate_authority
+
+import (
+	svcapitypes "github.com/aws-controllers-k8s/acmpca-controller/apis/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func customSetDefaults(
+	a *resource,
+	b *resource,
+) {
+	// Default value of UsageMode is GENERAL_PURPOSE
+	defaultUsageMode := aws.String("GENERAL_PURPOSE")
+
+	if ackcompare.IsNil(a.ko.Spec.UsageMode) && ackcompare.IsNotNil(b.ko.Spec.UsageMode) {
+		a.ko.Spec.UsageMode = defaultUsageMode
+	}
+
+	// Default value of KeyStorageSecurityStandard is FIPS_140_2_LEVEL_3_OR_HIGHER
+	defaultKeyStorageSecurityStandard := aws.String("FIPS_140_2_LEVEL_3_OR_HIGHER")
+
+	if ackcompare.IsNil(a.ko.Spec.KeyStorageSecurityStandard) && ackcompare.IsNotNil(b.ko.Spec.KeyStorageSecurityStandard) {
+		a.ko.Spec.KeyStorageSecurityStandard = defaultKeyStorageSecurityStandard
+	}
+
+	// Default value of RevocationConfiguration.CrlConfiguration.Enabled is false
+	defaultCrlConfigurationEnabled := aws.Bool(false)
+
+	// Default value of RevocationConfiguration.OcspConfiguration.Enabled is false
+	defaultOcspConfigurationEnabled := aws.Bool(false)
+
+	if ackcompare.IsNil(a.ko.Spec.RevocationConfiguration) && ackcompare.IsNotNil(b.ko.Spec.RevocationConfiguration) {
+		revocationConfiguration := &svcapitypes.RevocationConfiguration{}
+		revocationConfiguration.CRLConfiguration = &svcapitypes.CRLConfiguration{}
+		revocationConfiguration.CRLConfiguration.Enabled = defaultCrlConfigurationEnabled
+
+		revocationConfiguration.OCSPConfiguration = &svcapitypes.OCSPConfiguration{}
+		revocationConfiguration.OCSPConfiguration.Enabled = defaultOcspConfigurationEnabled
+
+		a.ko.Spec.RevocationConfiguration = revocationConfiguration
+	}
+}

--- a/pkg/resource/certificate_authority/delta.go
+++ b/pkg/resource/certificate_authority/delta.go
@@ -42,6 +42,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customSetDefaults(a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.CertificateAuthorityConfiguration, b.ko.Spec.CertificateAuthorityConfiguration) {
 		delta.Add("Spec.CertificateAuthorityConfiguration", a.ko.Spec.CertificateAuthorityConfiguration, b.ko.Spec.CertificateAuthorityConfiguration)

--- a/pkg/resource/certificate_authority/hooks.go
+++ b/pkg/resource/certificate_authority/hooks.go
@@ -16,6 +16,9 @@ package certificate_authority
 import (
 	"context"
 
+	svcapitypes "github.com/aws-controllers-k8s/acmpca-controller/apis/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/acmpca"
 )
 
@@ -32,4 +35,107 @@ func (rm *resourceManager) getCertificateAuthorityCsr(
 	}
 	csr := resp.Csr
 	return csr, err
+}
+
+// getTags gets tags from given CA.
+func (rm *resourceManager) getTags(
+	ctx context.Context,
+	resourceARN string,
+) ([]*svcapitypes.Tag, error) {
+	resp, err := rm.sdkapi.ListTagsWithContext(
+		ctx,
+		&svcsdk.ListTagsInput{
+			CertificateAuthorityArn: &resourceARN,
+		},
+	)
+	rm.metrics.RecordAPICall("GET", "ListTags", err)
+	if err != nil {
+		return nil, err
+	}
+	tags := resourceTagsFromSDKTags(resp.Tags)
+	return tags, nil
+}
+
+// syncTags updates tags of given CA to desired tags.
+func (rm *resourceManager) syncTags(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.syncTags")
+	defer func(err error) { exit(err) }(err)
+
+	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
+
+	desiredTags := ToACKTags(desired.ko.Spec.Tags)
+	latestTags := ToACKTags(latest.ko.Spec.Tags)
+
+	added, _, removed := ackcompare.GetTagsDifference(latestTags, desiredTags)
+
+	toAdd := FromACKTags(added)
+	toRemove := FromACKTags(removed)
+
+	/*var toDelete []*string
+	for _, removedElement := range toRemove {
+		toDelete = append(toDelete, removedElement.Key)
+	}*/
+
+	if len(toRemove) > 0 {
+		rlog.Debug("removing tags from CertificateAuthority", "tags", toRemove)
+		_, err = rm.sdkapi.UntagCertificateAuthorityWithContext(
+			ctx,
+			&svcsdk.UntagCertificateAuthorityInput{
+				CertificateAuthorityArn: arn,
+				Tags:                    sdkTagsFromResourceTags(toRemove),
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "UntagCertificateAuthority", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(toAdd) > 0 {
+		rlog.Debug("adding tags to CertificateAuthority", "tags", toAdd)
+		_, err = rm.sdkapi.TagCertificateAuthorityWithContext(
+			ctx,
+			&svcsdk.TagCertificateAuthorityInput{
+				CertificateAuthorityArn: arn,
+				Tags:                    sdkTagsFromResourceTags(toAdd),
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "TagCertificateAuthority", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func sdkTagsFromResourceTags(
+	rTags []*svcapitypes.Tag,
+) []*svcsdk.Tag {
+	tags := make([]*svcsdk.Tag, len(rTags))
+	for i := range rTags {
+		tags[i] = &svcsdk.Tag{
+			Key:   rTags[i].Key,
+			Value: rTags[i].Value,
+		}
+	}
+	return tags
+}
+
+func resourceTagsFromSDKTags(
+	sdkTags []*svcsdk.Tag,
+) []*svcapitypes.Tag {
+	tags := make([]*svcapitypes.Tag, len(sdkTags))
+	for i := range sdkTags {
+		tags[i] = &svcapitypes.Tag{
+			Key:   sdkTags[i].Key,
+			Value: sdkTags[i].Value,
+		}
+	}
+	return tags
 }

--- a/pkg/resource/certificate_authority_activation/hooks.go
+++ b/pkg/resource/certificate_authority_activation/hooks.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"sync"
 
-	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	client "github.com/aws-controllers-k8s/acmpca-controller/pkg/client"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/acmpca"

--- a/pkg/resource/certificate_authority_activation/sdk.go
+++ b/pkg/resource/certificate_authority_activation/sdk.go
@@ -139,6 +139,7 @@ func (rm *resourceManager) sdkDelete(
 	defer func() {
 		exit(err)
 	}()
+
 	// TODO(jaypipes): Figure this out...
 	return nil, nil
 

--- a/templates/hooks/certificate_authority/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/certificate_authority/sdk_read_one_post_set_output.go.tpl
@@ -1,0 +1,29 @@
+    resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
+    tags, err := rm.getTags(ctx, *resourceARN)
+    if err != nil {
+        return nil, err
+    }
+    ko.Spec.Tags = tags
+
+    if ko.Spec.KeyStorageSecurityStandard == nil {
+        ko.Spec.KeyStorageSecurityStandard = aws.String("FIPS_140_2_LEVEL_3_OR_HIGHER")
+    }
+
+    if ko.Spec.UsageMode == nil {
+        ko.Spec.UsageMode = aws.String("GENERAL_PURPOSE")
+    }
+
+    if ko.Spec.RevocationConfiguration == nil {
+        revocationConfiguration := &svcapitypes.RevocationConfiguration{}
+
+		revocationConfigurationCRLConfiguration := &svcapitypes.CRLConfiguration{}
+		revocationConfigurationCRLConfiguration.Enabled = aws.Bool(false)
+        revocationConfiguration.CRLConfiguration = revocationConfigurationCRLConfiguration
+
+        revocationConfigurationOCSPConfiguration := &svcapitypes.OCSPConfiguration{}
+		revocationConfigurationOCSPConfiguration.Enabled = aws.Bool(false)
+        revocationConfiguration.OCSPConfiguration = revocationConfigurationOCSPConfiguration
+
+		
+		ko.Spec.RevocationConfiguration = revocationConfiguration
+	}

--- a/templates/hooks/certificate_authority/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/certificate_authority/sdk_update_pre_build_request.go.tpl
@@ -1,0 +1,7 @@
+    latest, err = rm.sdkFind(ctx, latest)
+    if delta.DifferentAt("Spec.Tags") {
+		err := rm.syncTags(ctx, desired, latest)
+		if err != nil {
+			return nil, err
+		}
+	}

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -39,6 +39,16 @@ class ACMPCAValidator:
             assert tag in ca_tags
         except self.acmpca_client.exceptions.ClientError:
             pass
+    
+    def assert_not_in_ca_tags(self, ca_arn: str, key: str, val: str):
+        try:
+            aws_res = self.acmpca_client.list_tags(CertificateAuthorityArn=ca_arn, MaxResults=10)
+            ca_tags = aws_res["Tags"]
+            logging.info(aws_res["Tags"])
+            tag = {'Key': key, 'Value': val}
+            assert tag not in ca_tags
+        except self.acmpca_client.exceptions.ClientError:
+            pass
 
     def get_csr(self, ca_arn: str):
         try:

--- a/test/e2e/tests/test_root_ca.py
+++ b/test/e2e/tests/test_root_ca.py
@@ -107,6 +107,7 @@ def test_create_ca(acmpca_client):
 
     # Check Tags
     acmpca_validator.assert_ca_tags(ca_resource_arn, "tag2", "val2")
+    acmpca_validator.assert_not_in_ca_tags(ca_resource_arn, "tag1", "val1")
 
     # Check CSR
     assert 'status' in ca_cr

--- a/test/e2e/tests/test_root_ca.py
+++ b/test/e2e/tests/test_root_ca.py
@@ -95,6 +95,19 @@ def test_create_ca(acmpca_client):
     # Check Tags
     acmpca_validator.assert_ca_tags(ca_resource_arn, "tag1", "val1")
 
+    # Update CAActivation
+    patch = {"spec": {"tags": [{'key': 'tag2', 'value': 'val2'}]}}
+
+    # Patch k8s resource
+    patch_res = k8s.patch_custom_resource(ca_ref, patch)
+    logging.info(patch_res)
+    time.sleep(UPDATE_WAIT_AFTER_SECONDS) 
+    ca_cr = k8s.get_resource(ca_ref)
+    logging.info(ca_cr)
+
+    # Check Tags
+    acmpca_validator.assert_ca_tags(ca_resource_arn, "tag2", "val2")
+
     # Check CSR
     assert 'status' in ca_cr
     assert 'csr' in ca_cr['status']


### PR DESCRIPTION
Description of changes:
1. Set certain CA spec fields to be immutable
2. Implementing updating CA tags
3. Set certain CA spec fields to their default values if they're not set by the user

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
