### PR TITLE
Update CertificateAuthorityActivation custom find operation

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-03-13T20:48:59Z"
+  build_date: "2024-03-28T19:05:22Z"
   build_hash: af8006cb7248f0177e2a14b709c69c3a99a016ad
   go_version: go1.22.0
   version: v0.32.1
-api_directory_checksum: 16bbc1638d320137699b502cc4f1d1ea48331018
+api_directory_checksum: 66df0a0fb2b60ec0062ff3269109b58cbfc31dfe
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.6
 generator_config_info:
-  file_checksum: 1bd602454d19c2275cbfbdb3a7e9c33d65e4dce0
+  file_checksum: 579e5032eb2ae03ce6d6bca7276bf1f83c96a313
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -155,12 +155,15 @@ resources:
         references:
           resource: CertificateAuthority
           path: Status.ACKResourceMetadata.ARN
+        is_immutable: true
       Certificate:
         type: string
         is_secret: true
+        is_immutable: true
       CertificateChain:
         type: string
         is_secret: true
+        is_immutable: true
       Status:
         type: string
     find_operation:

--- a/generator.yaml
+++ b/generator.yaml
@@ -155,12 +155,15 @@ resources:
         references:
           resource: CertificateAuthority
           path: Status.ACKResourceMetadata.ARN
+        is_immutable: true
       Certificate:
         type: string
         is_secret: true
+        is_immutable: true
       CertificateChain:
         type: string
         is_secret: true
+        is_immutable: true
       Status:
         type: string
     find_operation:

--- a/pkg/resource/certificate_authority_activation/hooks.go
+++ b/pkg/resource/certificate_authority_activation/hooks.go
@@ -46,7 +46,7 @@ func (rm *resourceManager) customFindCertificateAuthorityActivation(
 	}()
 
 	if r.ko.Spec.CertificateAuthorityARN == nil && r.ko.Spec.CertificateAuthorityRef.From.Name == nil {
-		return nil, ackerr.Terminal
+		return nil, ackerr.NotFound
 	}
 
 	// lock runtime
@@ -125,10 +125,14 @@ func (rm *resourceManager) customFindCertificateAuthorityActivation(
 				}
 
 				if status == svcsdk.CertificateAuthorityStatusActive {
-					return nil, ackerr.Terminal
+					return nil, fmt.Errorf("CertificateAuthorityActivation resource already exists for this CertificateAuthority")
 				}
 			}
 		}
+	}
+
+	if numFound == 0 {
+		return nil, ackerr.NotFound
 	}
 
 	input := &svcsdk.DescribeCertificateAuthorityInput{}

--- a/pkg/resource/certificate_authority_activation/sdk.go
+++ b/pkg/resource/certificate_authority_activation/sdk.go
@@ -258,3 +258,21 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	// No terminal_errors specified for this resource in generator config
 	return false
 }
+
+// getImmutableFieldChanges returns list of immutable fields from the
+func (rm *resourceManager) getImmutableFieldChanges(
+	delta *ackcompare.Delta,
+) []string {
+	var fields []string
+	if delta.DifferentAt("Spec.Certificate") {
+		fields = append(fields, "Certificate")
+	}
+	if delta.DifferentAt("Spec.CertificateAuthorityARN") {
+		fields = append(fields, "CertificateAuthorityARN")
+	}
+	if delta.DifferentAt("Spec.CertificateChain") {
+		fields = append(fields, "CertificateChain")
+	}
+
+	return fields
+}


### PR DESCRIPTION
Description of changes:
1. Changed the error returned, from Terminal to NotFound, when a CertificateAuthorityActivation resource's CertificateAuthorityARN field is nil
2. Changed the error message, to "CertificateAuthorityActivation resource already exists for this CertificateAuthority", when a user attempts to create multiple CertificateAuthorityActivation resources for a CA
3. Check if the number of CertificateAuthorityActivation resources with the same ARN is 0, and return NotFound error
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
