### PR TITLE
Refactor CertificateAuthorityActivation Resource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-03-29T14:28:28Z"
-  build_hash: e8df4d5a4b86dea0e227786c2c3d213e5aeda97a
+  build_date: "2024-04-05T16:12:41Z"
+  build_hash: af8006cb7248f0177e2a14b709c69c3a99a016ad
   go_version: go1.22.0
   version: v0.33.0
 api_directory_checksum: 66df0a0fb2b60ec0062ff3269109b58cbfc31dfe
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.6
 generator_config_info:
-  file_checksum: 64dcd7f612f6ed8dafbf47adbc3265ce73ecff9b
+  file_checksum: 7a2c23bfd609f6085ccef2c46234ec909afda4c6
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -145,8 +145,6 @@ resources:
         code: customSetDefaults(a, b)
       sdk_create_post_build_request:
         template_path: hooks/certificate_authority_activation/sdk_create_post_build_request.go.tpl
-      sdk_update_post_build_request:
-        template_path: hooks/certificate_authority_activation/sdk_update_post_build_request.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/certificate_authority_activation/sdk_create_post_set_output.go.tpl
     fields:
@@ -155,12 +153,15 @@ resources:
         references:
           resource: CertificateAuthority
           path: Status.ACKResourceMetadata.ARN
+        is_immutable: true
       Certificate:
         type: string
         is_secret: true
+        is_immutable: true
       CertificateChain:
         type: string
         is_secret: true
+        is_immutable: true
       Status:
         type: string
     find_operation:

--- a/generator.yaml
+++ b/generator.yaml
@@ -145,8 +145,6 @@ resources:
         code: customSetDefaults(a, b)
       sdk_create_post_build_request:
         template_path: hooks/certificate_authority_activation/sdk_create_post_build_request.go.tpl
-      sdk_update_post_build_request:
-        template_path: hooks/certificate_authority_activation/sdk_update_post_build_request.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/certificate_authority_activation/sdk_create_post_set_output.go.tpl
     fields:
@@ -155,12 +153,15 @@ resources:
         references:
           resource: CertificateAuthority
           path: Status.ACKResourceMetadata.ARN
+        is_immutable: true
       Certificate:
         type: string
         is_secret: true
+        is_immutable: true
       CertificateChain:
         type: string
         is_secret: true
+        is_immutable: true
       Status:
         type: string
     find_operation:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -14,31 +14,14 @@
 package client
 
 import (
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 )
 
 var (
-	dynClient     *dynamic.DynamicClient
 	secretsClient corev1.SecretInterface
 )
-
-func GetDynamicClient() (client *dynamic.DynamicClient, err error) {
-	if dynClient == nil {
-		config, err := rest.InClusterConfig()
-		if err != nil {
-			return nil, err
-		}
-
-		dynClient, err = dynamic.NewForConfig(config)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return dynClient, nil
-}
 
 func GetSecretsClient(
 	namespace string,

--- a/pkg/resource/certificate_authority_activation/hooks.go
+++ b/pkg/resource/certificate_authority_activation/hooks.go
@@ -16,8 +16,6 @@ package certificate_authority_activation
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"sync"
 
 	client "github.com/aws-controllers-k8s/acmpca-controller/pkg/client"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -26,13 +24,7 @@ import (
 	svcsdk "github.com/aws/aws-sdk-go/service/acmpca"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-)
-
-var (
-	mu sync.Mutex
 )
 
 func (rm *resourceManager) customFindCertificateAuthorityActivation(
@@ -44,91 +36,11 @@ func (rm *resourceManager) customFindCertificateAuthorityActivation(
 	defer func() {
 		exit(err)
 	}()
-
-	if r.ko.Spec.CertificateAuthorityARN == nil && r.ko.Spec.CertificateAuthorityRef.From.Name == nil {
-		return nil, ackerr.Terminal
-	}
-
-	// lock runtime
-	mu.Lock()
-	defer mu.Unlock()
-
-	// List all the CertificateAuthorityActivations
-	dynClient, err := client.GetDynamicClient()
-	if err != nil {
-		return nil, err
-	}
-
-	if r.ko.Spec.CertificateAuthorityARN == nil && r.ko.Spec.CertificateAuthorityRef != nil {
-		var caResource = schema.GroupVersionResource{Group: "acmpca.services.k8s.aws", Version: "v1alpha1", Resource: "certificateauthorities"}
-		ca, err := dynClient.Resource(caResource).Namespace(r.MetaObject().GetNamespace()).Get(ctx, *r.ko.Spec.CertificateAuthorityRef.From.Name, metav1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-		certificateAuthorityARN, found, err := unstructured.NestedString(ca.UnstructuredContent(), "status", "ackResourceMetadata", "arn")
-		if err != nil {
-			return nil, err
-		}
-		if !found {
-			return nil, fmt.Errorf("arn field not found on CertificateAuthority status")
-		}
-		r.ko.Spec.CertificateAuthorityARN = &certificateAuthorityARN
-	}
-
-	var caActivationResource = schema.GroupVersionResource{Group: "acmpca.services.k8s.aws", Version: "v1alpha1", Resource: "certificateauthorityactivations"}
-	list, err := dynClient.Resource(caActivationResource).Namespace(r.MetaObject().GetNamespace()).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	numFound := 0
-
-	for _, item := range list.Items {
-
-		certificateAuthorityARN, found, err := unstructured.NestedString(item.UnstructuredContent(), "spec", "certificateAuthorityARN")
-		if err != nil {
-			return nil, err
-		}
-
-		if !found {
-			certificateAuthorityRef, found, err := unstructured.NestedString(item.UnstructuredContent(), "spec", "certificateAuthorityRef", "from", "name")
-			if err != nil {
-				return nil, err
-			}
-			if !found {
-				return nil, fmt.Errorf("certificateAuthorityARN or certificateAuthorityRef field not found on CertificateAuthorityActivation spec")
-			}
-			var caResource = schema.GroupVersionResource{Group: "acmpca.services.k8s.aws", Version: "v1alpha1", Resource: "certificateauthorities"}
-			ca, err := dynClient.Resource(caResource).Namespace(r.MetaObject().GetNamespace()).Get(ctx, certificateAuthorityRef, metav1.GetOptions{})
-			if err != nil {
-				return nil, err
-			}
-			certificateAuthorityARN, found, err = unstructured.NestedString(ca.UnstructuredContent(), "status", "ackResourceMetadata", "arn")
-			if err != nil {
-				return nil, err
-			}
-			if !found {
-				return nil, fmt.Errorf("arn field not found on CertificateAuthority status")
-			}
-		}
-
-		if certificateAuthorityARN == *r.ko.Spec.CertificateAuthorityARN {
-			numFound++
-			if numFound > 1 {
-				status, found, err := unstructured.NestedString(item.Object, "spec", "status")
-				if err != nil {
-					return nil, err
-				}
-
-				if !found {
-					return nil, fmt.Errorf("status field not found on CertificateAuthorityActivation spec")
-				}
-
-				if status == svcsdk.CertificateAuthorityStatusActive {
-					return nil, ackerr.Terminal
-				}
-			}
-		}
+	// If any required fields in the input shape are missing, AWS resource is
+	// not created yet. Return NotFound here to indicate to callers that the
+	// resource isn't yet created.
+	if r.ko.Spec.CertificateAuthorityARN == nil {
+		return nil, ackerr.NotFound
 	}
 
 	input := &svcsdk.DescribeCertificateAuthorityInput{}
@@ -149,10 +61,8 @@ func (rm *resourceManager) customFindCertificateAuthorityActivation(
 		ko.Spec.Status = nil
 	}
 
-	if numFound == 1 {
-		if ko.Spec.Status == nil || *ko.Spec.Status == svcsdk.CertificateAuthorityStatusCreating || *ko.Spec.Status == svcsdk.CertificateAuthorityStatusPendingCertificate {
-			return nil, ackerr.NotFound
-		}
+	if ko.Spec.Status == nil || *ko.Spec.Status == svcsdk.CertificateAuthorityStatusCreating || *ko.Spec.Status == svcsdk.CertificateAuthorityStatusPendingCertificate {
+		return nil, ackerr.NotFound
 	}
 
 	rm.setStatusDefaults(ko)

--- a/pkg/resource/certificate_authority_activation/sdk.go
+++ b/pkg/resource/certificate_authority_activation/sdk.go
@@ -114,6 +114,24 @@ func (rm *resourceManager) sdkCreate(
 			return nil, err
 		}
 	}
+
+	if desired.ko.Spec.Status != nil && *desired.ko.Spec.Status == svcsdk.CertificateAuthorityStatusDisabled {
+		updateInput := &svcsdk.UpdateCertificateAuthorityInput{}
+
+		updateInput.SetStatus(*desired.ko.Spec.Status)
+
+		if desired.ko.Spec.CertificateAuthorityARN != nil {
+			updateInput.SetCertificateAuthorityArn(*desired.ko.Spec.CertificateAuthorityARN)
+		}
+
+		var updateResp *svcsdk.UpdateCertificateAuthorityOutput
+		_ = updateResp
+		updateResp, err = rm.sdkapi.UpdateCertificateAuthorityWithContext(ctx, updateInput)
+		rm.metrics.RecordAPICall("UPDATE", "UpdateCertificateAuthority", err)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &resource{ko}, nil
 }
 
@@ -257,4 +275,22 @@ func (rm *resourceManager) updateConditions(
 func (rm *resourceManager) terminalAWSError(err error) bool {
 	// No terminal_errors specified for this resource in generator config
 	return false
+}
+
+// getImmutableFieldChanges returns list of immutable fields from the
+func (rm *resourceManager) getImmutableFieldChanges(
+	delta *ackcompare.Delta,
+) []string {
+	var fields []string
+	if delta.DifferentAt("Spec.Certificate") {
+		fields = append(fields, "Certificate")
+	}
+	if delta.DifferentAt("Spec.CertificateAuthorityARN") {
+		fields = append(fields, "CertificateAuthorityARN")
+	}
+	if delta.DifferentAt("Spec.CertificateChain") {
+		fields = append(fields, "CertificateChain")
+	}
+
+	return fields
 }

--- a/templates/hooks/certificate_authority_activation/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/certificate_authority_activation/sdk_create_post_set_output.go.tpl
@@ -4,3 +4,21 @@
             return nil, err
         }
     }
+    
+    if desired.ko.Spec.Status != nil && *desired.ko.Spec.Status == svcsdk.CertificateAuthorityStatusDisabled {
+        updateInput := &svcsdk.UpdateCertificateAuthorityInput{}
+
+        updateInput.SetStatus(*desired.ko.Spec.Status)
+
+        if desired.ko.Spec.CertificateAuthorityARN != nil {
+            updateInput.SetCertificateAuthorityArn(*desired.ko.Spec.CertificateAuthorityARN)
+        }
+
+        var updateResp *svcsdk.UpdateCertificateAuthorityOutput
+        _ = updateResp
+        updateResp, err = rm.sdkapi.UpdateCertificateAuthorityWithContext(ctx, updateInput)
+        rm.metrics.RecordAPICall("UPDATE", "UpdateCertificateAuthority", err)
+        if err != nil {
+            return nil, err
+        }
+    }

--- a/templates/hooks/certificate_authority_activation/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/certificate_authority_activation/sdk_update_post_build_request.go.tpl
@@ -1,3 +1,0 @@
-    if desired.ko.Spec.Status != nil && (*desired.ko.Spec.Status == svcsdk.CertificateAuthorityStatusActive || *desired.ko.Spec.Status == svcsdk.CertificateAuthorityStatusDisabled) {
-		input.SetStatus(*desired.ko.Spec.Status)
-	}

--- a/test/e2e/resources/certificate_authority_activation_ref.yaml
+++ b/test/e2e/resources/certificate_authority_activation_ref.yaml
@@ -14,4 +14,4 @@ spec:
     namespace: $CERTIFICATE_SECRET_NAMESPACE
     name: $CERTIFICATE_SECRET_NAME
     key: $CERTIFICATE_SECRET_KEY
-  status: ACTIVE
+  status: $STATUS

--- a/test/e2e/resources/subordinate_certificate.yaml
+++ b/test/e2e/resources/subordinate_certificate.yaml
@@ -1,0 +1,18 @@
+apiVersion: acmpca.services.k8s.aws/v1alpha1
+kind: Certificate
+metadata:
+  name: $NAME
+  annotations:
+    acmpca.services.k8s.aws/certificate-secret-namespace: $CERTIFICATE_SEC_NS
+    acmpca.services.k8s.aws/certificate-secret-name: $CERTIFICATE_SEC_NAME
+    acmpca.services.k8s.aws/certificate-secret-key: $CERTIFICATE_SEC_KEY
+spec:
+  certificateAuthorityARN: $CA_ARN
+  csrRef:
+    from:
+      name: $CA_NAME
+  signingAlgorithm: SHA256WITHRSA
+  templateARN: $TEMPLATE_ARN
+  validity:
+    type: DAYS
+    value: 90

--- a/test/e2e/resources/subordinate_certificate_authority.yaml
+++ b/test/e2e/resources/subordinate_certificate_authority.yaml
@@ -1,0 +1,18 @@
+apiVersion: acmpca.services.k8s.aws/v1alpha1
+kind: CertificateAuthority
+metadata:
+  name: $NAME
+spec:
+  certificateAuthorityType: SUBORDINATE
+  certificateAuthorityConfiguration:
+    subject:
+      commonName: $COMMON_NAME
+      country: $COUNTRY
+      locality: $LOCALITY
+      organization: $ORG
+      state: $STATE
+    keyAlgorithm: RSA_2048
+    signingAlgorithm: SHA256WITHRSA
+  tags:
+    - key: tag1
+      value: val1

--- a/test/e2e/resources/subordinate_certificate_authority_activation.yaml
+++ b/test/e2e/resources/subordinate_certificate_authority_activation.yaml
@@ -1,0 +1,18 @@
+apiVersion: acmpca.services.k8s.aws/v1alpha1
+kind: CertificateAuthorityActivation
+metadata:
+  name: $NAME
+  annotations:
+    acmpca.services.k8s.aws/chain-secret-namespace: $COMPLETE_CERTIFICATE_CHAIN_SEC_NS
+    acmpca.services.k8s.aws/chain-secret-name: $COMPLETE_CERTIFICATE_CHAIN_SEC_NAME
+    acmpca.services.k8s.aws/chain-secret-key: $COMPLETE_CERTIFICATE_CHAIN_SEC_KEY
+spec:
+  certificateAuthorityARN: $CA_ARN
+  certificate:
+    namespace: $CERTIFICATE_SECRET_NAMESPACE
+    name: $CERTIFICATE_SECRET_NAME
+    key: $CERTIFICATE_SECRET_KEY
+  certificateChain:
+    namespace: $CERTIFICATE_CHAIN_SEC_NS
+    name: $CERTIFICATE_CHAIN_SEC_NAME
+    key: $CERTIFICATE_CHAIN_SEC_KEY

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -15,6 +15,7 @@
 """
 
 import logging
+import time
 
 class ACMPCAValidator:
     def __init__(self, acmpca_client):
@@ -55,4 +56,57 @@ class ACMPCAValidator:
             assert certificate is not None
             return certificate
         except self.acmpca_client.exceptions.ClientError:
+            pass
+
+    def create_root_ca(self):
+        try:
+            aws_res = self.acmpca_client.create_certificate_authority(
+                CertificateAuthorityConfiguration={
+                    'KeyAlgorithm': 'RSA_2048',
+                    'SigningAlgorithm': 'SHA256WITHRSA',
+                    'Subject': {
+                        'Country': 'US',
+                        'Organization': 'Example Organization',
+                        'State': 'Virginia',
+                        'CommonName': 'www.example.com',
+                        'Locality': 'Arlington',
+                    }
+                },
+                CertificateAuthorityType='ROOT'
+            )
+            ca_arn = aws_res['CertificateAuthorityArn']
+            logging.info(ca_arn)
+            assert ca_arn is not None
+            time.sleep(10)
+
+            csr = self.get_csr(ca_arn=ca_arn)
+            logging.info(csr)
+            assert csr is not None
+            time.sleep(10)
+
+            aws_res = self.acmpca_client.issue_certificate(
+                CertificateAuthorityArn=ca_arn,
+                Csr=csr,
+                SigningAlgorithm='SHA256WITHRSA',
+                TemplateArn='arn:aws:acm-pca:::template/RootCACertificate/V1',
+                Validity={
+                    'Value': 100,
+                    'Type': 'DAYS'
+                }
+            )
+            cert_arn = aws_res['CertificateArn']
+            logging.info(cert_arn)
+            assert cert_arn is not None
+
+            return ca_arn, cert_arn
+        except self.acmpca_client.exceptions.ClientError as error:
+            logging.info(error)
+
+    def delete_ca(self, ca_arn: str):
+        try:
+            self.acmpca_client.delete_certificate_authority(
+                CertificateAuthorityArn=ca_arn,
+                PermanentDeletionTimeInDays=7
+            )
+        except self.acmpca_client.exceptions.ClientError as error:
             pass

--- a/test/e2e/tests/test_ca_activation.py
+++ b/test/e2e/tests/test_ca_activation.py
@@ -50,7 +50,7 @@ def create_certificate_chain_secret(k8s_secret):
         "default",
         random_suffix_name("certificate-chain-secret", 50),
         "certificateChain",
-        "test"
+        "value"
     )
     yield secret
 
@@ -85,12 +85,58 @@ def simple_certificate_authority():
     assert ca_cr is not None
     assert k8s.get_resource_exists(ca_ref)
     logging.info(ca_cr)
-    logging.info(ca_ref)
 
     ca_resource_arn =  k8s.get_resource_arn(ca_cr)
     assert ca_resource_arn is not None
 
     yield (ca_cr, ca_name)
+
+    #Delete CA k8s resource
+    _, deleted = k8s.delete_custom_resource(ca_ref)
+    assert deleted is True
+
+@pytest.fixture(scope="module")
+def subordinate_certificate_authority(acmpca_client, simple_ca_activation):
+
+    (root_ca_arn, act_cr, act_ref, certificate_chain_secret, root_ca_cert_arn) = simple_ca_activation
+
+    acmpca_validator = ACMPCAValidator(acmpca_client)
+    acmpca_validator.assert_certificate_authority(root_ca_arn, "ACTIVE")
+    
+    ca_name = random_suffix_name("subordinate-certificate-authority", 50)
+    replacements = {}
+    suffix = random_suffix_name("", 2)
+    replacements["NAME"] = ca_name
+    replacements["COMMON_NAME"] = "www.example" + suffix + ".com"
+    replacements["COUNTRY"] = "US"
+    replacements["LOCALITY"] = "Arlington"
+    replacements["ORG"] = "Example Organization " + suffix
+    replacements["STATE"] = "Virginia"
+
+    # Load CA CR
+    ca_resource_data = load_acmpca_resource(
+        "subordinate_certificate_authority",
+        additional_replacements=replacements,
+    )
+
+    # Create k8s resource
+    ca_ref = k8s.create_reference(
+        CRD_GROUP, CRD_VERSION, "certificateauthorities",
+        ca_name, namespace="default",
+    )
+    k8s.create_custom_resource(ca_ref, ca_resource_data)
+    ca_cr = k8s.wait_resource_consumed_by_controller(ca_ref)
+
+    time.sleep(30)
+
+    assert ca_cr is not None
+    assert k8s.get_resource_exists(ca_ref)
+    logging.info(ca_cr)
+
+    ca_resource_arn =  k8s.get_resource_arn(ca_cr)
+    assert ca_resource_arn is not None
+
+    yield (ca_cr, ca_name, root_ca_arn, root_ca_cert_arn, certificate_chain_secret)
 
     #Delete CA k8s resource
     _, deleted = k8s.delete_custom_resource(ca_ref)
@@ -104,7 +150,6 @@ def simple_root_certificate(acmpca_client, create_secret, simple_certificate_aut
     cert_name = random_suffix_name("certificate", 30)
 
     secret = create_secret
-    logging.info(secret)
     
     replacements = {}
     replacements["NAME"] = cert_name
@@ -148,6 +193,54 @@ def simple_root_certificate(acmpca_client, create_secret, simple_certificate_aut
     assert deleted is True
 
 @pytest.fixture(scope="module")
+def subordinate_ca_certificate(create_secret, subordinate_certificate_authority):
+    (sub_ca_cr, sub_ca_name, root_ca_arn, root_ca_cert_arn, certificate_chain_secret) = subordinate_certificate_authority
+    sub_ca_arn = sub_ca_cr['status']['ackResourceMetadata']['arn']
+
+    sub_ca_cert_name = random_suffix_name("certificate", 30)
+
+    sub_ca_cert_secret = create_secret
+    
+    replacements = {}
+    replacements["NAME"] = sub_ca_cert_name
+    replacements["CA_NAME"] = sub_ca_name
+    replacements["CA_ARN"] = root_ca_arn
+    replacements["CERTIFICATE_SEC_NS"] = sub_ca_cert_secret.ns
+    replacements["CERTIFICATE_SEC_NAME"] = sub_ca_cert_secret.name
+    replacements["CERTIFICATE_SEC_KEY"] = sub_ca_cert_secret.key
+    replacements["TEMPLATE_ARN"] = "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen2/V1"
+
+    # Load Certificate CR
+    resource_data = load_acmpca_resource(
+        "subordinate_certificate",
+        additional_replacements=replacements,
+    )
+
+    # Create k8s resource
+    ref = k8s.create_reference(
+        CRD_GROUP, CRD_VERSION, "certificates",
+        sub_ca_cert_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+    logging.info(cr)
+
+    sub_ca_cert_arn =  k8s.get_resource_arn(cr)
+    assert sub_ca_cert_arn is not None
+
+    yield (sub_ca_arn, sub_ca_cert_arn, root_ca_arn, root_ca_cert_arn, sub_ca_cert_secret, certificate_chain_secret)
+
+    #Delete Certificate k8s resource
+    _, deleted = k8s.delete_custom_resource(ref)
+    assert deleted is True
+
+
+@pytest.fixture(scope="module")
 def simple_ca_activation(simple_root_certificate, create_certificate_chain_secret, acmpca_client):
 
     (ca_name, ca_arn, secret, cert_arn) = simple_root_certificate
@@ -189,16 +282,80 @@ def simple_ca_activation(simple_root_certificate, create_certificate_chain_secre
     yield (ca_arn, act_cr, act_ref, certificate_chain_secret, cert_arn)
 
     # Update CAActivation
-    act_cr["spec"]["status"] = "DISABLED"
-
-    # Patch k8s resource
-    patch_res = k8s.patch_custom_resource(act_ref, act_cr)
+    updates = {
+        "spec": {
+            "status": "DISABLED"
+        },
+    }
+    patch_res = k8s.patch_custom_resource(act_ref, updates)
     logging.info(patch_res)
     time.sleep(UPDATE_WAIT_AFTER_SECONDS) 
     
     # Check CA status is DISABLED
     acmpca_validator = ACMPCAValidator(acmpca_client)
     acmpca_validator.assert_certificate_authority(ca_arn, "DISABLED")
+
+    #Delete CAActivation k8s resource
+    _, deleted = k8s.delete_custom_resource(act_ref)
+    assert deleted is True
+
+@pytest.fixture(scope="module")
+def subordinate_ca_activation(subordinate_ca_certificate, create_certificate_chain_secret, acmpca_client):
+
+    (sub_ca_arn, sub_ca_cert_arn, root_ca_arn, root_ca_cert_arn, sub_ca_cert_secret, certificate_chain_secret) = subordinate_ca_certificate
+
+    complete_certificate_chain_secret = create_certificate_chain_secret
+    
+    activation_name = random_suffix_name("certificate-authority-activation", 50)
+        
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["NAME"] = activation_name
+    replacements["CA_ARN"] = sub_ca_arn
+    replacements["CERTIFICATE_SECRET_NAMESPACE"] = sub_ca_cert_secret.ns
+    replacements["CERTIFICATE_SECRET_NAME"] = sub_ca_cert_secret.name
+    replacements["CERTIFICATE_SECRET_KEY"] = sub_ca_cert_secret.key
+    replacements["CERTIFICATE_CHAIN_SEC_NS"] = certificate_chain_secret.ns
+    replacements["CERTIFICATE_CHAIN_SEC_NAME"] = certificate_chain_secret.name
+    replacements["CERTIFICATE_CHAIN_SEC_KEY"] = certificate_chain_secret.key
+    replacements["COMPLETE_CERTIFICATE_CHAIN_SEC_NS"] = complete_certificate_chain_secret.ns
+    replacements["COMPLETE_CERTIFICATE_CHAIN_SEC_NAME"] = complete_certificate_chain_secret.name
+    replacements["COMPLETE_CERTIFICATE_CHAIN_SEC_KEY"] = complete_certificate_chain_secret.key
+    
+    # Load CAActivation CR
+    act_resource_data = load_acmpca_resource(
+        "subordinate_certificate_authority_activation",
+        additional_replacements=replacements,
+    )
+
+    # Create k8s resource
+    act_ref = k8s.create_reference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+        activation_name, namespace="default",
+    )
+    k8s.create_custom_resource(act_ref, act_resource_data)
+    act_cr = k8s.wait_resource_consumed_by_controller(act_ref)
+
+    time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+    assert act_cr is not None
+    assert k8s.get_resource_exists(act_ref)
+    logging.info(act_cr)
+
+    yield (sub_ca_arn, sub_ca_cert_arn, root_ca_arn, root_ca_cert_arn, complete_certificate_chain_secret, sub_ca_cert_secret)
+
+    # Update CAActivation
+    updates = {
+        "spec": {
+            "status": "DISABLED"
+        },
+    }
+    patch_res = k8s.patch_custom_resource(act_ref, updates)
+    logging.info(patch_res)
+    time.sleep(UPDATE_WAIT_AFTER_SECONDS) 
+    
+    # Check CA status is DISABLED
+    acmpca_validator = ACMPCAValidator(acmpca_client)
+    acmpca_validator.assert_certificate_authority(sub_ca_arn, "DISABLED")
 
     #Delete CAActivation k8s resource
     _, deleted = k8s.delete_custom_resource(act_ref)
@@ -222,6 +379,7 @@ def simple_ca_activation_with_ref(simple_root_certificate, create_certificate_ch
     replacements["CERTIFICATE_CHAIN_SEC_NS"] = certificate_chain_secret.ns
     replacements["CERTIFICATE_CHAIN_SEC_NAME"] = certificate_chain_secret.name
     replacements["CERTIFICATE_CHAIN_SEC_KEY"] = certificate_chain_secret.key
+    replacements["STATUS"] = "ACTIVE"
     
     # Load CAActivation CR
     act_resource_data = load_acmpca_resource(
@@ -246,10 +404,12 @@ def simple_ca_activation_with_ref(simple_root_certificate, create_certificate_ch
     yield (ca_arn, act_cr, act_ref, certificate_chain_secret, cert_arn)
 
     # Update CAActivation
-    act_cr["spec"]["status"] = "DISABLED"
-
-    # Patch k8s resource
-    patch_res = k8s.patch_custom_resource(act_ref, act_cr)
+    updates = {
+        "spec": {
+            "status": "DISABLED"
+        },
+    }
+    patch_res = k8s.patch_custom_resource(act_ref, updates)
     logging.info(patch_res)
     time.sleep(UPDATE_WAIT_AFTER_SECONDS) 
     
@@ -261,6 +421,51 @@ def simple_ca_activation_with_ref(simple_root_certificate, create_certificate_ch
     _, deleted = k8s.delete_custom_resource(act_ref)
     assert deleted is True
     
+@pytest.fixture(scope="module")
+def simple_ca_activation_status_disabled(simple_root_certificate, create_certificate_chain_secret, acmpca_client):
+
+    (ca_name, ca_arn, secret, cert_arn) = simple_root_certificate
+
+    certificate_chain_secret = create_certificate_chain_secret
+
+    activation_name = random_suffix_name("certificate-authority-activation", 50)
+        
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["NAME"] = activation_name
+    replacements["CA_NAME"] = ca_name
+    replacements["CERTIFICATE_SECRET_NAMESPACE"] = secret.ns
+    replacements["CERTIFICATE_SECRET_NAME"] = secret.name
+    replacements["CERTIFICATE_SECRET_KEY"] = secret.key
+    replacements["CERTIFICATE_CHAIN_SEC_NS"] = certificate_chain_secret.ns
+    replacements["CERTIFICATE_CHAIN_SEC_NAME"] = certificate_chain_secret.name
+    replacements["CERTIFICATE_CHAIN_SEC_KEY"] = certificate_chain_secret.key
+    replacements["STATUS"] = "DISABLED"
+    
+    # Load CAActivation CR
+    act_resource_data = load_acmpca_resource(
+        "certificate_authority_activation_ref",
+        additional_replacements=replacements,
+    )
+
+    # Create k8s resource
+    act_ref = k8s.create_reference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+        activation_name, namespace="default",
+    )
+    k8s.create_custom_resource(act_ref, act_resource_data)
+    act_cr = k8s.wait_resource_consumed_by_controller(act_ref)
+
+    time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+    assert act_cr is not None
+    assert k8s.get_resource_exists(act_ref)
+    logging.info(act_cr)
+
+    yield (ca_arn, certificate_chain_secret, cert_arn)
+
+    #Delete CAActivation k8s resource
+    _, deleted = k8s.delete_custom_resource(act_ref)
+    assert deleted is True
 
 @service_marker
 class TestCertificateAuthorityActivation:
@@ -297,7 +502,54 @@ class TestCertificateAuthorityActivation:
         api_response = client.CoreV1Api(_api_client).read_namespaced_secret(certificate_chain_secret.name, certificate_chain_secret.ns).data
 
         assert certificate_chain_secret.key in api_response
-        assert base64.b64decode(api_response[certificate_chain_secret.key]).decode("ascii") == cert 
+        assert base64.b64decode(api_response[certificate_chain_secret.key]).decode("ascii") == cert
+
+    def test_ca_activation_update(self, acmpca_client, simple_ca_activation):
+        
+        (ca_arn, act_cr, act_ref, certificate_chain_secret, cert_arn) = simple_ca_activation
+
+        # Check CA status is ACTIVE
+        acmpca_validator = ACMPCAValidator(acmpca_client)
+        acmpca_validator.assert_certificate_authority(ca_arn, "ACTIVE")
+
+        # Update Status to DISABLED
+        updates = {
+            "spec": {
+                "status": "DISABLED"
+            },
+        }
+        patch_res = k8s.patch_custom_resource(act_ref, updates)
+        logging.info(patch_res)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS) 
+        
+        # Check CA status is DISABLED
+        acmpca_validator.assert_certificate_authority(ca_arn, "DISABLED")
+
+        # Update Status to ACTIVE 
+        updates = {
+            "spec": {
+                "status": "ACTIVE"
+            },
+        }
+        patch_res = k8s.patch_custom_resource(act_ref, updates)
+        logging.info(patch_res)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS) 
+        
+        # Check CA status is ACTIVE
+        acmpca_validator.assert_certificate_authority(ca_arn, "ACTIVE")
+
+        # Update Status to PENDING_CERTIFICATE
+        updates = {
+            "spec": {
+                "status": "PENDING_CERTIFICATE"
+            },
+        }
+        patch_res = k8s.patch_custom_resource(act_ref, updates)
+        logging.info(patch_res)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS) 
+        
+        # Check CA status is still ACTIVE
+        acmpca_validator.assert_certificate_authority(ca_arn, "ACTIVE")
 
     def test_ca_activation_deletion(self, acmpca_client, simple_root_certificate):
         (ca_name, ca_arn, secret, cert_arn) = simple_root_certificate
@@ -342,3 +594,159 @@ class TestCertificateAuthorityActivation:
 
         # Check CA is DISABLED after CAActivation is deleted
         acmpca_validator.assert_certificate_authority(ca_arn, "DISABLED")
+
+    def test_out_of_band_ca_activation(self, acmpca_client, k8s_secret):
+        acmpca_validator = ACMPCAValidator(acmpca_client)
+
+        # Create Root CA 
+        ca_arn, cert_arn = acmpca_validator.create_root_ca()
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        # Get Root CA Certificate
+        cert = acmpca_validator.get_certificate(ca_arn=ca_arn, cert_arn=cert_arn)
+
+        # Create Secrete for Root CA Certificate
+        test_secret = k8s_secret(
+            "default",
+            random_suffix_name("certificate-secret", 50),
+            "certificate",
+            cert
+        )
+
+        # Create CAActivation resource
+        
+        activation_name = random_suffix_name("certificate-authority-activation", 50)
+            
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["NAME"] = activation_name
+        replacements["CA_ARN"] = ca_arn
+        replacements["CERTIFICATE_SECRET_NAMESPACE"] = test_secret.ns
+        replacements["CERTIFICATE_SECRET_NAME"] = test_secret.name
+        replacements["CERTIFICATE_SECRET_KEY"] = test_secret.key
+        
+        # Load CAActivation CR
+        act_resource_data = load_acmpca_resource(
+            "certificate_authority_activation",
+            additional_replacements=replacements,
+        )
+
+        # Create k8s resource
+        act_ref = k8s.create_reference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            activation_name, namespace="default",
+        )
+        k8s.create_custom_resource(act_ref, act_resource_data)
+        act_cr = k8s.wait_resource_consumed_by_controller(act_ref)
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        assert act_cr is not None
+        assert k8s.get_resource_exists(act_ref)
+        logging.info(act_cr)
+
+        # Check CA status is ACTIVE
+        acmpca_validator = ACMPCAValidator(acmpca_client)
+        acmpca_validator.assert_certificate_authority(ca_arn, "ACTIVE") 
+
+        # Delete CAActivation k8s resource
+        _, deleted = k8s.delete_custom_resource(act_ref)
+        assert deleted is True
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # Check CA is DISABLED after CAActivation is deleted
+        acmpca_validator.assert_certificate_authority(ca_arn, "DISABLED")
+
+        # Delete CA
+        acmpca_validator.delete_ca(ca_arn)
+        acmpca_validator.assert_certificate_authority(ca_arn, "DELETED")
+
+    def test_subordinate_ca_activation(self, acmpca_client, subordinate_ca_activation):
+        (sub_ca_arn, sub_ca_cert_arn, root_ca_arn, root_ca_cert_arn, complete_certificate_chain_secret, sub_ca_cert_secret) = subordinate_ca_activation
+
+        # Check CA status is ACTIVE
+        acmpca_validator = ACMPCAValidator(acmpca_client)
+        acmpca_validator.assert_certificate_authority(sub_ca_arn, "ACTIVE")
+
+        sub_ca_cert = acmpca_validator.get_certificate(ca_arn=root_ca_arn, cert_arn=sub_ca_cert_arn)
+        assert sub_ca_cert is not None
+
+        # Check certificate is in secret
+        _api_client = _get_k8s_api_client()
+        api_response = client.CoreV1Api(_api_client).read_namespaced_secret(sub_ca_cert_secret.name, sub_ca_cert_secret.ns).data
+
+        assert sub_ca_cert_secret.key in api_response
+        assert base64.b64decode(api_response[sub_ca_cert_secret.key]).decode("ascii") == sub_ca_cert
+
+        root_ca_cert = acmpca_validator.get_certificate(ca_arn=root_ca_arn, cert_arn=root_ca_cert_arn)
+        assert root_ca_cert is not None
+
+        complete_certificate_chain = sub_ca_cert + "\n" + root_ca_cert
+
+        # Check certificate chain is in secret
+        api_response = client.CoreV1Api(_api_client).read_namespaced_secret(complete_certificate_chain_secret.name, complete_certificate_chain_secret.ns).data
+
+        assert complete_certificate_chain_secret.key in api_response
+        assert base64.b64decode(api_response[complete_certificate_chain_secret.key]).decode("ascii") == complete_certificate_chain
+
+    def test_ca_activation_status_disabled(self, acmpca_client, simple_ca_activation_status_disabled):
+        (ca_arn, certificate_chain_secret, cert_arn) = simple_ca_activation_status_disabled
+
+        # Check CA status is DISABLED
+        acmpca_validator = ACMPCAValidator(acmpca_client)
+        acmpca_validator.assert_certificate_authority(ca_arn, "DISABLED")
+
+        cert = acmpca_validator.get_certificate(ca_arn=ca_arn, cert_arn=cert_arn)
+
+        # Check certificate chain is in secret
+        _api_client = _get_k8s_api_client()
+        api_response = client.CoreV1Api(_api_client).read_namespaced_secret(certificate_chain_secret.name, certificate_chain_secret.ns).data
+
+        assert certificate_chain_secret.key in api_response
+        assert base64.b64decode(api_response[certificate_chain_secret.key]).decode("ascii") == cert
+
+    def test_second_activation(self, acmpca_client, simple_ca_activation):
+        
+        (ca_arn, act_cr, act_ref, certificate_chain_secret, cert_arn) = simple_ca_activation
+
+        # Check CA status is ACTIVE
+        acmpca_validator = ACMPCAValidator(acmpca_client)
+        acmpca_validator.assert_certificate_authority(ca_arn, "ACTIVE")
+
+        activation_name = random_suffix_name("certificate-authority-activation", 50)
+            
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["NAME"] = activation_name
+        replacements["CA_ARN"] = ca_arn
+        replacements["CERTIFICATE_SECRET_NAMESPACE"] = certificate_chain_secret.ns
+        replacements["CERTIFICATE_SECRET_NAME"] = certificate_chain_secret.name
+        replacements["CERTIFICATE_SECRET_KEY"] = certificate_chain_secret.key
+        
+        # Load CAActivation CR
+        act_resource_data = load_acmpca_resource(
+            "certificate_authority_activation",
+            additional_replacements=replacements,
+        )
+
+        # Create k8s resource
+        act_2_ref = k8s.create_reference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            activation_name, namespace="default",
+        )
+        k8s.create_custom_resource(act_2_ref, act_resource_data)
+        act_2_cr = k8s.wait_resource_consumed_by_controller(act_2_ref)
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        assert act_2_cr is not None
+        assert k8s.get_resource_exists(act_2_ref)
+        logging.info(act_2_cr)
+
+        assert 'status' in act_2_cr
+        assert 'conditions' in act_2_cr['status']
+        assert 'message' in act_2_cr['status']['conditions'][0]
+        assert act_2_cr['status']['conditions'][0]['message'] == "Resource already exists"
+
+        _, deleted = k8s.delete_custom_resource(act_2_ref)
+        assert deleted is True


### PR DESCRIPTION
Description of changes:

1. Remove calls to K8s API List call in activation resource custom Find method
2. Add hook that will disable a CA after the activation resource is created, if the Status field was "DISABLED"
3. Remove sdk_update_post_build_request hook (no longer needed because we use a custom update operation)
4. Add more test cases

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
