### PR TITLE
Update CA resource customSetDefaults method for RevocationConfiguration field

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-04-23T13:51:34Z"
+  build_date: "2024-04-24T17:14:25Z"
   build_hash: af8006cb7248f0177e2a14b709c69c3a99a016ad
   go_version: go1.22.0
   version: v0.33.0

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-04-24T17:14:25Z"
+  build_date: "2024-04-26T15:06:31Z"
   build_hash: af8006cb7248f0177e2a14b709c69c3a99a016ad
   go_version: go1.22.0
   version: v0.33.0
@@ -7,7 +7,7 @@ api_directory_checksum: 14ee2b48df20458271bcddc87436760812fd6ccd
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.6
 generator_config_info:
-  file_checksum: 5e732471cd7372bbdab8104a11bf3ac2c0dd6511
+  file_checksum: a819c4eed6f806afa486a515b59ebdda3d614e24
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -37,6 +37,8 @@ resources:
     hooks:
       delta_pre_compare:
         code: customSetDefaults(a, b)
+      sdk_create_post_build_request:
+        template_path: hooks/certificate_authority/sdk_create_post_build_request.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/certificate_authority/sdk_update_pre_build_request.go.tpl
       sdk_read_one_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -37,6 +37,8 @@ resources:
     hooks:
       delta_pre_compare:
         code: customSetDefaults(a, b)
+      sdk_create_post_build_request:
+        template_path: hooks/certificate_authority/sdk_create_post_build_request.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/certificate_authority/sdk_update_pre_build_request.go.tpl
       sdk_read_one_post_set_output:

--- a/pkg/resource/certificate_authority/custom_delta.go
+++ b/pkg/resource/certificate_authority/custom_delta.go
@@ -37,20 +37,16 @@ func customSetDefaults(
 		a.ko.Spec.KeyStorageSecurityStandard = defaultKeyStorageSecurityStandard
 	}
 
-	// Default value of RevocationConfiguration.CrlConfiguration.Enabled is false
-	defaultCrlConfigurationEnabled := aws.Bool(false)
-
-	// Default value of RevocationConfiguration.OcspConfiguration.Enabled is false
-	defaultOcspConfigurationEnabled := aws.Bool(false)
-
 	if ackcompare.IsNil(a.ko.Spec.RevocationConfiguration) && ackcompare.IsNotNil(b.ko.Spec.RevocationConfiguration) {
-		revocationConfiguration := &svcapitypes.RevocationConfiguration{}
-		revocationConfiguration.CRLConfiguration = &svcapitypes.CRLConfiguration{}
-		revocationConfiguration.CRLConfiguration.Enabled = defaultCrlConfigurationEnabled
+		a.ko.Spec.RevocationConfiguration = &svcapitypes.RevocationConfiguration{}
+	}
 
-		revocationConfiguration.OCSPConfiguration = &svcapitypes.OCSPConfiguration{}
-		revocationConfiguration.OCSPConfiguration.Enabled = defaultOcspConfigurationEnabled
-
-		a.ko.Spec.RevocationConfiguration = revocationConfiguration
+	if ackcompare.IsNotNil(a.ko.Spec.RevocationConfiguration) && ackcompare.IsNotNil(b.ko.Spec.RevocationConfiguration) {
+		if ackcompare.IsNil(a.ko.Spec.RevocationConfiguration.CRLConfiguration) && ackcompare.IsNotNil(b.ko.Spec.RevocationConfiguration.CRLConfiguration) {
+			a.ko.Spec.RevocationConfiguration.CRLConfiguration = b.ko.Spec.RevocationConfiguration.CRLConfiguration
+		}
+		if ackcompare.IsNil(a.ko.Spec.RevocationConfiguration.OCSPConfiguration) && ackcompare.IsNotNil(b.ko.Spec.RevocationConfiguration.OCSPConfiguration) {
+			a.ko.Spec.RevocationConfiguration.OCSPConfiguration = b.ko.Spec.RevocationConfiguration.OCSPConfiguration
+		}
 	}
 }

--- a/pkg/resource/certificate_authority/sdk.go
+++ b/pkg/resource/certificate_authority/sdk.go
@@ -425,28 +425,6 @@ func (rm *resourceManager) sdkFind(
 	}
 	ko.Spec.Tags = tags
 
-	if ko.Spec.KeyStorageSecurityStandard == nil {
-		ko.Spec.KeyStorageSecurityStandard = aws.String("FIPS_140_2_LEVEL_3_OR_HIGHER")
-	}
-
-	if ko.Spec.UsageMode == nil {
-		ko.Spec.UsageMode = aws.String("GENERAL_PURPOSE")
-	}
-
-	if ko.Spec.RevocationConfiguration == nil {
-		revocationConfiguration := &svcapitypes.RevocationConfiguration{}
-
-		revocationConfigurationCRLConfiguration := &svcapitypes.CRLConfiguration{}
-		revocationConfigurationCRLConfiguration.Enabled = aws.Bool(false)
-		revocationConfiguration.CRLConfiguration = revocationConfigurationCRLConfiguration
-
-		revocationConfigurationOCSPConfiguration := &svcapitypes.OCSPConfiguration{}
-		revocationConfigurationOCSPConfiguration.Enabled = aws.Bool(false)
-		revocationConfiguration.OCSPConfiguration = revocationConfigurationOCSPConfiguration
-
-		ko.Spec.RevocationConfiguration = revocationConfiguration
-	}
-
 	ko.Status.CertificateSigningRequest, err = rm.getCertificateAuthorityCsr(ctx, *resourceARN)
 	if err != nil && strings.HasPrefix(err.Error(), "RequestInProgressException") {
 		return nil, ackrequeue.NeededAfter(err, ackrequeue.DefaultRequeueAfterDuration)

--- a/pkg/resource/certificate_authority/sdk.go
+++ b/pkg/resource/certificate_authority/sdk.go
@@ -475,6 +475,7 @@ func (rm *resourceManager) sdkCreate(
 	if err != nil {
 		return nil, err
 	}
+	input.SetIdempotencyToken(string(desired.ko.ObjectMeta.UID))
 
 	var resp *svcsdk.CreateCertificateAuthorityOutput
 	_ = resp

--- a/templates/hooks/certificate_authority/sdk_create_post_build_request.go.tpl
+++ b/templates/hooks/certificate_authority/sdk_create_post_build_request.go.tpl
@@ -1,0 +1,1 @@
+input.SetIdempotencyToken(string(desired.ko.ObjectMeta.UID))

--- a/templates/hooks/certificate_authority/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/certificate_authority/sdk_read_one_post_set_output.go.tpl
@@ -5,29 +5,6 @@
     }
     ko.Spec.Tags = tags
 
-    if ko.Spec.KeyStorageSecurityStandard == nil {
-        ko.Spec.KeyStorageSecurityStandard = aws.String("FIPS_140_2_LEVEL_3_OR_HIGHER")
-    }
-
-    if ko.Spec.UsageMode == nil {
-        ko.Spec.UsageMode = aws.String("GENERAL_PURPOSE")
-    }
-
-    if ko.Spec.RevocationConfiguration == nil {
-        revocationConfiguration := &svcapitypes.RevocationConfiguration{}
-
-		revocationConfigurationCRLConfiguration := &svcapitypes.CRLConfiguration{}
-		revocationConfigurationCRLConfiguration.Enabled = aws.Bool(false)
-        revocationConfiguration.CRLConfiguration = revocationConfigurationCRLConfiguration
-
-        revocationConfigurationOCSPConfiguration := &svcapitypes.OCSPConfiguration{}
-		revocationConfigurationOCSPConfiguration.Enabled = aws.Bool(false)
-        revocationConfiguration.OCSPConfiguration = revocationConfigurationOCSPConfiguration
-
-		
-		ko.Spec.RevocationConfiguration = revocationConfiguration
-	}
-    
     ko.Status.CertificateSigningRequest, err = rm.getCertificateAuthorityCsr(ctx, *resourceARN)
     if err != nil && strings.HasPrefix(err.Error(), "RequestInProgressException") {
         return nil, ackrequeue.NeededAfter(err, ackrequeue.DefaultRequeueAfterDuration)

--- a/test/e2e/resources/certificate_authority.yaml
+++ b/test/e2e/resources/certificate_authority.yaml
@@ -16,3 +16,8 @@ spec:
   tags:
     - key: tag1
       value: val1
+  revocationConfiguration:
+    crlConfiguration:
+      enabled: False
+    ocspConfiguration:
+      enabled: False

--- a/test/e2e/resources/certificate_authority_defaults.yaml
+++ b/test/e2e/resources/certificate_authority_defaults.yaml
@@ -3,7 +3,7 @@ kind: CertificateAuthority
 metadata:
   name: $NAME
 spec:
-  type: SUBORDINATE
+  type: ROOT
   certificateAuthorityConfiguration:
     subject:
       commonName: $COMMON_NAME
@@ -16,6 +16,3 @@ spec:
   tags:
     - key: tag1
       value: val1
-  revocationConfiguration:
-    ocspConfiguration:
-      enabled: False

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -57,3 +57,16 @@ class ACMPCAValidator:
             return certificate
         except self.acmpca_client.exceptions.ClientError:
             pass
+
+    def disable_active_ca(self, ca_arn: str):
+        try:
+            aws_res = self.acmpca_client.describe_certificate_authority(CertificateAuthorityArn=ca_arn)
+            ca = aws_res["CertificateAuthority"]
+            if ca["Status"] == "ACTIVE":
+                self.acmpca_client.update_certificate_authority(CertificateAuthorityArn=ca_arn,Status='DISABLED')
+                aws_res = self.acmpca_client.describe_certificate_authority(CertificateAuthorityArn=ca_arn)
+                ca = aws_res["CertificateAuthority"]
+                logging.info(ca["Status"])
+                assert ca["Status"] == "DISABLED"
+        except self.acmpca_client.exceptions.ClientError:
+            pass

--- a/test/e2e/tests/test_ca.py
+++ b/test/e2e/tests/test_ca.py
@@ -50,7 +50,7 @@ def simple_certificate_authority(acmpca_client):
 
     # Load CA CR
     ca_resource_data = load_acmpca_resource(
-        "certificate_authority",
+        "certificate_authority_defaults",
         additional_replacements=replacements,
     )
 

--- a/test/e2e/tests/test_ca_activation.py
+++ b/test/e2e/tests/test_ca_activation.py
@@ -30,6 +30,7 @@ from e2e.fixtures import k8s_secret
 
 RESOURCE_PLURAL = "certificateauthorityactivations"
 
+CREATE_CA_WAIT_AFTER_SECONDS = 30
 CREATE_WAIT_AFTER_SECONDS = 10
 UPDATE_WAIT_AFTER_SECONDS = 10
 DELETE_WAIT_AFTER_SECONDS = 10
@@ -80,7 +81,7 @@ def simple_certificate_authority():
     k8s.create_custom_resource(ca_ref, ca_resource_data)
     ca_cr = k8s.wait_resource_consumed_by_controller(ca_ref)
 
-    time.sleep(30)
+    time.sleep(CREATE_CA_WAIT_AFTER_SECONDS)
 
     assert ca_cr is not None
     assert k8s.get_resource_exists(ca_ref)
@@ -127,7 +128,7 @@ def subordinate_certificate_authority(acmpca_client, simple_ca_activation):
     k8s.create_custom_resource(ca_ref, ca_resource_data)
     ca_cr = k8s.wait_resource_consumed_by_controller(ca_ref)
 
-    time.sleep(30)
+    time.sleep(CREATE_CA_WAIT_AFTER_SECONDS)
 
     assert ca_cr is not None
     assert k8s.get_resource_exists(ca_ref)
@@ -501,7 +502,7 @@ class TestCertificateAuthorityActivation:
         k8s.create_custom_resource(act_ref, act_resource_data)
         act_cr = k8s.wait_resource_consumed_by_controller(act_ref)
 
-        time.sleep(30)
+        time.sleep(CREATE_CA_WAIT_AFTER_SECONDS)
 
         assert act_cr is not None
         assert k8s.get_resource_exists(act_ref)

--- a/test/e2e/tests/test_ca_activation.py
+++ b/test/e2e/tests/test_ca_activation.py
@@ -56,7 +56,7 @@ def create_certificate_chain_secret(k8s_secret):
     yield secret
 
 @pytest.fixture(scope="module")
-def simple_certificate_authority():
+def simple_certificate_authority(acmpca_client):
     ca_name = random_suffix_name("certificate-authority", 50)
     replacements = {}
     suffix = random_suffix_name("", 10)
@@ -91,6 +91,10 @@ def simple_certificate_authority():
     assert ca_resource_arn is not None
 
     yield (ca_cr,ca_ref, ca_name)
+
+    #Disable CA if status is ACTIVE
+    acmpca_validator = ACMPCAValidator(acmpca_client)
+    acmpca_validator.disable_active_ca(ca_resource_arn)
 
     #Delete CA k8s resource
     _, deleted = k8s.delete_custom_resource(ca_ref)

--- a/test/e2e/tests/test_ca_activation.py
+++ b/test/e2e/tests/test_ca_activation.py
@@ -501,7 +501,7 @@ class TestCertificateAuthorityActivation:
         k8s.create_custom_resource(act_ref, act_resource_data)
         act_cr = k8s.wait_resource_consumed_by_controller(act_ref)
 
-        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+        time.sleep(30)
 
         assert act_cr is not None
         assert k8s.get_resource_exists(act_ref)

--- a/test/e2e/tests/test_certificate.py
+++ b/test/e2e/tests/test_certificate.py
@@ -30,6 +30,7 @@ from e2e.fixtures import k8s_secret
 
 RESOURCE_PLURAL = "certificates"
 
+CREATE_CA_WAIT_AFTER_SECONDS = 30
 CREATE_WAIT_AFTER_SECONDS = 10
 UPDATE_WAIT_AFTER_SECONDS = 10
 DELETE_WAIT_AFTER_SECONDS = 10
@@ -70,7 +71,7 @@ def simple_certificate_authority():
     k8s.create_custom_resource(ca_ref, ca_resource_data)
     ca_cr = k8s.wait_resource_consumed_by_controller(ca_ref)
 
-    time.sleep(30)
+    time.sleep(CREATE_CA_WAIT_AFTER_SECONDS)
 
     assert ca_cr is not None
     assert k8s.get_resource_exists(ca_ref)


### PR DESCRIPTION
Description of changes:
1. Update the CA resource customSetDefaults method to set default values of the RevocationConfiguration field
2. Update e2e tests to test for different values of the RevocationConfiguration field
3. Set CA's IdempotencyToken to the UUID of the resource

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
