### PR TITLE
Update customUpdateCertificateAuthorityActivation

### DIFF
--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/acmpca-controller
-  newTag: 0.0.12
+  newTag: 0.0.13

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: acmpca-chart
 description: A Helm chart for the ACK service controller for AWS Private Certificate Authority (PCA)
-version: 0.0.12
-appVersion: 0.0.12
+version: 0.0.13
+appVersion: 0.0.13
 home: https://github.com/aws-controllers-k8s/acmpca-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/acmpca-controller:0.0.12".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/acmpca-controller:0.0.13".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/acmpca-controller
-  tag: 0.0.12
+  tag: 0.0.13
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/certificate_authority_activation/hooks.go
+++ b/pkg/resource/certificate_authority_activation/hooks.go
@@ -83,7 +83,7 @@ func (rm *resourceManager) customUpdateCertificateAuthorityActivation(
 		input.SetCertificateAuthorityArn(*desired.ko.Spec.CertificateAuthorityARN)
 	}
 
-	if desired.ko.Spec.Status != nil && (*desired.ko.Spec.Status == svcsdk.CertificateAuthorityStatusActive || *desired.ko.Spec.Status == svcsdk.CertificateAuthorityStatusDisabled) {
+	if desired.ko.Spec.Status != nil {
 		input.SetStatus(*desired.ko.Spec.Status)
 	}
 

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -68,5 +68,5 @@ class ACMPCAValidator:
                 ca = aws_res["CertificateAuthority"]
                 logging.info(ca["Status"])
                 assert ca["Status"] == "DISABLED"
-        except self.acmpca_client.exceptions.ClientError:
-            pass
+        except self.acmpca_client.exceptions.ClientError as error:
+            return error

--- a/test/e2e/tests/test_ca_activation.py
+++ b/test/e2e/tests/test_ca_activation.py
@@ -94,7 +94,7 @@ def simple_certificate_authority(acmpca_client):
 
     #Disable CA if status is ACTIVE
     acmpca_validator = ACMPCAValidator(acmpca_client)
-    acmpca_validator.disable_active_ca(ca_resource_arn)
+    assert acmpca_validator.disable_active_ca(ca_resource_arn) is None
 
     #Delete CA k8s resource
     _, deleted = k8s.delete_custom_resource(ca_ref)
@@ -555,19 +555,6 @@ class TestCertificateAuthorityActivation:
         time.sleep(UPDATE_WAIT_AFTER_SECONDS) 
         
         # Check CA status is ACTIVE
-        acmpca_validator.assert_certificate_authority(ca_arn, "ACTIVE")
-
-        # Update Status to PENDING_CERTIFICATE
-        updates = {
-            "spec": {
-                "status": "PENDING_CERTIFICATE"
-            },
-        }
-        patch_res = k8s.patch_custom_resource(act_ref, updates)
-        logging.info(patch_res)
-        time.sleep(UPDATE_WAIT_AFTER_SECONDS) 
-        
-        # Check CA status is still ACTIVE
         acmpca_validator.assert_certificate_authority(ca_arn, "ACTIVE")
 
         #Delete CAActivation k8s resource


### PR DESCRIPTION
Description of changes:
1. Remove check if status is ACTIVE or DISABLED before calling UpdateCertificateAuthority. This isn't needed because UpdateCertificateAuthority will return an InvalidArgsException if the status is not ACTIVE or DISABLED.
2. Release artifacts for release v0.0.13

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
