### PR TITLE
Update Certificate resource writeCertificateToSecret method

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2024-08-29T17:01:24Z"
+  build_date: "2024-09-05T13:35:46Z"
   build_hash: f8f98563404066ac3340db0a049d2e530e5c51cc
   go_version: go1.22.5
   version: v0.38.1
-api_directory_checksum: 14ee2b48df20458271bcddc87436760812fd6ccd
+api_directory_checksum: bd1c805e13428d024256fc04295c87e9bee1524c
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.6
 generator_config_info:

--- a/pkg/resource/certificate/hooks.go
+++ b/pkg/resource/certificate/hooks.go
@@ -21,17 +21,17 @@ import (
 
 func (rm *resourceManager) writeCertificateToSecret(
 	ctx context.Context,
-	certificate string,
+	certificate,
 	resourceNamespace string,
 	secretKeyReference *ackv1alpha1.SecretKeyReference,
-) (err error) {
+) error {
 
 	namespace := resourceNamespace
 	if secretKeyReference.SecretReference.Namespace != "" {
 		namespace = secretKeyReference.SecretReference.Namespace
 	}
 
-	err = rm.rr.WriteToSecret(ctx, certificate, namespace, secretKeyReference.SecretReference.Name, secretKeyReference.Key)
+	err := rm.rr.WriteToSecret(ctx, certificate, namespace, secretKeyReference.SecretReference.Name, secretKeyReference.Key)
 	rm.metrics.RecordAPICall("PATCH", "writeCertificateToSecret", err)
 	if err != nil {
 		return err

--- a/pkg/resource/certificate/sdk.go
+++ b/pkg/resource/certificate/sdk.go
@@ -100,7 +100,7 @@ func (rm *resourceManager) sdkFind(
 	ko := r.ko.DeepCopy()
 
 	rm.setStatusDefaults(ko)
-	err = rm.writeCertificateToSecret(ctx, *resp.Certificate, r.ko.ObjectMeta.GetNamespace(), r.ko.Spec.CertificateOutput)
+	err = rm.writeCertificateToSecret(ctx, *resp.Certificate, r.ko.GetNamespace(), r.ko.Spec.CertificateOutput)
 	if err != nil && strings.HasPrefix(err.Error(), "RequestInProgressException") {
 		return &resource{ko}, ackrequeue.NeededAfter(err, ackrequeue.DefaultRequeueAfterDuration)
 	}

--- a/templates/hooks/certificate/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/certificate/sdk_read_one_post_set_output.go.tpl
@@ -1,4 +1,4 @@
-    err = rm.writeCertificateToSecret(ctx, *resp.Certificate, r.ko.ObjectMeta.GetNamespace(), r.ko.Spec.CertificateOutput)
+    err = rm.writeCertificateToSecret(ctx, *resp.Certificate, r.ko.GetNamespace(), r.ko.Spec.CertificateOutput)
     if err != nil && strings.HasPrefix(err.Error(), "RequestInProgressException") {
         return &resource{ko}, ackrequeue.NeededAfter(err, ackrequeue.DefaultRequeueAfterDuration)
     }


### PR DESCRIPTION
Description of changes:
Update writeCertificateToSecret to be consistent with the CertificateAuthorityActivation resource's writeCertificateChainToSecret method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
