### PR TITLE
tests: Ready condition rename for acmpca-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,3 +89,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.49.6 h1:yNldzF5kzLBRvKlKz1S0bkvc2+04R1kt13KfBWQBfFA=
 github.com/aws/aws-sdk-go v1.49.6/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
@@ -84,6 +82,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.54.0 h1:Mxf2oUm5Skgf0sLik5otKE5+I2+0ziC1aRWZJOwRiWQ=
+github.com/gustavodiaz7722/ack-runtime v0.54.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@26ff5ff62bfef2177ff18b9fc26c6289f01181c9
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@77f6bc5602557fe48e0dd157fefbd97a6aa3e54b

--- a/test/e2e/tests/test_ca_hierarchy.py
+++ b/test/e2e/tests/test_ca_hierarchy.py
@@ -167,7 +167,7 @@ def certificate_authority_hierarchy(
     for resource in resource_data:
         logging.info(resource)
         k8s.create_custom_resource(references[i], resource)
-        assert k8s.wait_on_condition(references[i], "ACK.ResourceSynced", "True", wait_periods=15)
+        assert k8s.wait_on_condition(references[i], "Ready", "True", wait_periods=15)
         i += 1
 
     time.sleep(180)
@@ -181,7 +181,7 @@ def certificate_authority_hierarchy(
     end_entity_cert_cr = k8s.wait_resource_consumed_by_controller(end_entity_cert_ref)
 
     for ref in references:
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=15)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=15)
 
     assert ca_cr is not None
     assert k8s.get_resource_exists(ca_ref)


### PR DESCRIPTION
This PR updates test files to the Ready condition:

- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.